### PR TITLE
Fix types syntax

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -468,7 +468,7 @@ declare namespace MobileMessagingReactNative {
          * @param {Function} onSuccess. Success callback
          * @param {Function} onError. Error callback
          */
-        sendContextualData(data: string, allMultiThreadStrategy: boolean, onSuccess = () => void, onError = (error: string) => void): void;
+        sendContextualData(data: string, allMultiThreadStrategy: boolean, onSuccess: () => void, onError: (error: string) => void): void;
 
         /**
          * Set chat language


### PR DESCRIPTION
The version 6.4.0 brought syntax error in type definitions of `sendContextualData` method, this PR fixes it.