### PR TITLE
Update Installation type to add optional pushRegistrationId

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -106,6 +106,7 @@ declare namespace MobileMessagingReactNative {
         applicationUserId?: string | undefined;
         deviceName?: string | undefined;
         customAttributes?: Record<string, string | number | boolean> | undefined;
+        pushRegistrationId?: string;
     }
 
     export interface UserIdentity {


### PR DESCRIPTION
The user guide mentions doing this to get the pushRegistrationId

```
mobileMessaging.getInstallation(
    installation => {
        // Here you can get pushRegistrationId with installation.pushRegistrationId
    }
);
```

however it doesn't exist in the types so when using this in a Typescript project you get an error